### PR TITLE
Make the publish script fail when any command fails

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,5 +1,7 @@
 # make the script fail for any failed command
 set -e
+# make the script display the commands it runs to help debugging failures
+set -x
 
 # configure env
 git config --global user.email 'waldio.webdesign@gmail.com'

--- a/publish.sh
+++ b/publish.sh
@@ -1,3 +1,6 @@
+# make the script fail for any failed command
+set -e
+
 # configure env
 git config --global user.email 'waldio.webdesign@gmail.com'
 git config --global user.name 'WouterJ.nl bot'

--- a/publish.sh
+++ b/publish.sh
@@ -8,7 +8,9 @@ git config --global user.email 'waldio.webdesign@gmail.com'
 git config --global user.name 'WouterJ.nl bot'
 
 # checkout publish branch
-git branch -D master
+if [ "`git show-ref --heads master`" ]; then
+  git branch -D master
+fi
 git checkout -b master
 
 # build site


### PR DESCRIPTION
Without this, all commands are always executed and Travis can fail only when the push fails.