### PR TITLE
Add the CSS source map to the ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /vendor/
 .sass-cache
 *.css
+*.css.map


### PR DESCRIPTION
Sass generates a source map when compiling the CSS.