### PR TITLE
Split the build script from the publication on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ before_script:
   - composer install --prefer-dist
 
 script:
-  - sh publish.sh
+  - sh build.sh
+
+after_success:
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sh publish.sh; fi
 
 env:
   global:

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+# make the script fail for any failed command
+set -e
+# make the script display the commands it runs to help debugging failures
+set -x
+
+# build site
+sass source/css/wouterj.scss:source/css/wouterj.css --style compressed --no-cache
+./vendor/bin/sculpin generate --env prod
+touch output_prod/.nojekyll

--- a/publish.sh
+++ b/publish.sh
@@ -1,29 +1,27 @@
+#!/usr/bin/env sh
 # make the script fail for any failed command
 set -e
 # make the script display the commands it runs to help debugging failures
 set -x
 
-# configure env
-git config --global user.email 'waldio.webdesign@gmail.com'
-git config --global user.name 'WouterJ.nl bot'
+# Go to the output directory
+cd output_prod
 
-# checkout publish branch
-if [ "`git show-ref --heads master`" ]; then
-  git branch -D master
+# Remove the existing repo if it exists
+if [ -d ".git" ]; then
+    rm -rf .git
 fi
-git checkout -b master
 
-# build site
-sass source/css/wouterj.scss:source/css/wouterj.css --style compressed --no-cache
-./vendor/bin/sculpin generate --env prod
-touch output_prod/.nojekyll
+# Create a repo for the built website for the master branch
+git init
+
+# configure env (locally)
+git config user.email 'waldio.webdesign@gmail.com'
+git config user.name 'WouterJ.nl bot'
 
 # commit build
-git add -f output_prod
+git add .
 git commit -m "Build website"
-
-# only push output
-git filter-branch --subdirectory-filter output_prod/ -f
 
 # push to GitHub Pages
 git push "https://github.com/WouterJ/wouterj.github.com" -f master


### PR DESCRIPTION
This allows running the publication only for branch pushes and not for pull requests. Closes #13
The creation of the orphan commit for the master branch with the built website has been refactored to avoid having to filtering the branch each time, which is faster.
The new script also avoids changing the git email and username globally, making it much safer to run the publish task locally (through bldr for instance). The previous publish script caught me when changing the git config globally when running it locally: https://github.com/FriendsOfSymfony/FOSElasticaBundle/commit/3c87cc16c7dd9419b771e3a3678b86481ab3c2f0 should have been commited with my authorship, not the ``
WouterJ.nl bot`` one